### PR TITLE
added \n option

### DIFF
--- a/bin/generator.js
+++ b/bin/generator.js
@@ -48,7 +48,7 @@ function bodyGen (obj, kind) {
         res.push(parse('res += ' + compositeName[kind]));
     }
     if (objKinds.length > 0) {
-        res.push(parse(`indent += '  '`));
+        res.push(parse(`indent += spaceString`));
         objKinds.forEach(function (key) {
             if (arrayKeys[key] === undefined) {
                 res.push(parse(
@@ -64,7 +64,7 @@ function bodyGen (obj, kind) {
                 ));
             }
         });
-        res.push(parse(`indent = indent.slice(0,-2)`));
+        res.push(parse(`indent = indent.slice(0,-spaceNum)`));
         if (unparented[kind] === undefined) {
             res.push(parse(`res += indent`));
         }
@@ -78,12 +78,24 @@ function bodyGen (obj, kind) {
 function funcObject (obj) {
     var res = esprima.parse(`
         'use strict';
-        var res, indent;
+        var res, indent, spaceNum, spaceString = '';
         var exprGen = {};
-        function gen (node) {
+        function gen (node, space) {
+            spaceNum = space
+            for(var i=0; i<space; i++){
+              spaceString += ' '
+            }
             res = '';
-            indent = '\\n';
+            if (space) {
+              indent = '\\n';
+            } else {
+              indent = ''
+            }
             exprGen[node.kind](node);
+            // removes the leading newline
+            if(space){
+              res = res.slice(1)
+            }
             return res;
         }
         exports.generate = gen;

--- a/test/basic.js
+++ b/test/basic.js
@@ -23,7 +23,7 @@ describe('basic', function () {
                     name: 'y'
                 }
             }
-        })).to.eq('\n(i32.add\n  (get_local\n    $x\n  )\n  (get_local\n    $y\n  )\n)');
+        }, 2)).to.eq('(i32.add\n  (get_local\n    $x\n  )\n  (get_local\n    $y\n  )\n)');
         done();
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -9,8 +9,13 @@ var fs = require('fs'),
 var src = path.resolve(__dirname, '../wast-parser/results/');
 
 var astFileNames = fs.readdirSync(src);
-
 describe('codegen', function () {
+
+    var startT = process.hrtime()
+    before(function() {
+      startT = process.hrtime()
+    });
+
     astFileNames.forEach(function (name) {
         it(name, function (done) {
             if (name.match('^(.*)js$')) {
@@ -22,7 +27,7 @@ describe('codegen', function () {
                         if (err) { throw err; }
                         ast = jsof.p(jsData);
                         var res = codegen.generate(ast);
-                        console.log(res + '\n\n');
+                        // console.log(res + '\n\n');
                         done();
                     }
                 );
@@ -31,4 +36,10 @@ describe('codegen', function () {
             }
         });
     });
+
+    after(function () {
+      var diff = process.hrtime(startT)
+      console.log('test took %d nanoseconds', diff[0] * 1e9 + diff[1]);
+    });
 });
+


### PR DESCRIPTION
```
spaceing = 2
generate({
            kind: 'binop',
            type: 'i32',
            operator: 'add',
            left: {
                kind: 'get_local',
                id: {
                    kind: 'identifier',
                    name: 'x'
                }
            },
            right: {
                kind: 'get_local',
                id: {
                    kind: 'identifier',
                    name: 'y'
                }
            }
        }, spaceing))
```
will result in
`(i32.add\n  (get_local\n    $x\n  )\n  (get_local\n    $y\n  )\n)`    
with no spacing the result will be
`(i32.add (get_local $x)(get_local $y))`    
